### PR TITLE
Fix Debug Toolbar styling

### DIFF
--- a/tin/templates/debug_toolbar/base.html
+++ b/tin/templates/debug_toolbar/base.html
@@ -1,0 +1,9 @@
+{% extends 'debug_toolbar/base.html' %}
+
+{% block css %}{{ block.super }}
+<style>
+    :root {
+        color-scheme: light !important;
+    }
+</style>
+{% endblock %}


### PR DESCRIPTION
I don't know what I did but I'm fairly certain tin isn't supposed to, under any circumstances, look like this
![image](https://github.com/tjcsl/tin/assets/110117391/58fbb928-50ee-4ac2-b39a-8c034983449b)
