### PR TITLE
Replace `os.path` with `pathlib.Path`

### DIFF
--- a/create_debug_users.py
+++ b/create_debug_users.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
-import os
 import subprocess
 import sys
+from pathlib import Path
 
 if not __file__.endswith("shell.py"):
     subprocess.call(
         [
             sys.executable,
-            os.path.join(os.path.dirname(__file__), "manage.py"),
+            Path(__file__).parent / "manage.py",
             "shell",
             "-c",
-            open(__file__).read(),
+            Path(__file__).read_text(encoding="utf-8"),
         ]
     )
     exit()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,10 +91,14 @@ select = [
     "PL",
     # Pytest
     "PT",
+    # flake8-use-pathlib
+    "PTH",
     # pygrep hooks
     "PGH",
     # ruff
     "RUF",
+    # flake8-print
+    "T20",
     # pyupgrade
     "UP",
 ]

--- a/tin/apps/assignments/models.py
+++ b/tin/apps/assignments/models.py
@@ -234,9 +234,6 @@ class Assignment(models.Model):
 
         fpath = settings.MEDIA_ROOT / f"assignment-{self.id}" / file_name
 
-        # Is this needed?
-        fpath.parent.mkdir(parents=True, exist_ok=True)
-
         args = get_assignment_sandbox_args(
             ["sh", "-c", 'cat >"$1"', "sh", fpath],
             network_access=False,

--- a/tin/apps/assignments/tasks.py
+++ b/tin/apps/assignments/tasks.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 
 import mosspy
 from celery import shared_task
@@ -23,7 +22,7 @@ def run_moss(moss_result_id):
         students = assignment.course.students.all()
 
     download_folder = moss_result.download_folder
-    os.makedirs(download_folder, mode=0o755, exist_ok=True)
+    download_folder.mkdir(mode=0o755, parents=True, exist_ok=True)
 
     extension = moss_result.extension
 
@@ -42,10 +41,11 @@ def run_moss(moss_result_id):
         published_submission = publishes.latest().submission if publishes else latest_submission
         if published_submission is not None:
             file_with_header = published_submission.file_text_with_header
-            with open(os.path.join(download_folder, f"{student.username}.{extension}"), "w") as f:
-                f.write(file_with_header)
+            assert isinstance(file_with_header, str)
+            temp_path = download_folder / f"{student.username}.{extension}"
+            temp_path.write_text(file_with_header)
             runner.addFile(
-                os.path.join(download_folder, f"{student.username}.{extension}"),
+                download_folder / f"{student.username}.{extension}",
                 f"{student.first_name}_{student.last_name}",
             )
 

--- a/tin/apps/assignments/tasks.py
+++ b/tin/apps/assignments/tasks.py
@@ -41,9 +41,8 @@ def run_moss(moss_result_id):
         published_submission = publishes.latest().submission if publishes else latest_submission
         if published_submission is not None:
             file_with_header = published_submission.file_text_with_header
-            assert isinstance(file_with_header, str)
             temp_path = download_folder / f"{student.username}.{extension}"
-            temp_path.write_text(file_with_header)
+            temp_path.write_text(str(file_with_header))
             runner.addFile(
                 download_folder / f"{student.username}.{extension}",
                 f"{student.first_name}_{student.last_name}",

--- a/tin/apps/assignments/views.py
+++ b/tin/apps/assignments/views.py
@@ -157,9 +157,7 @@ def show_view(request, assignment_id):
             "folder": assignment.folder,
             "assignment": assignment,
             "students_and_submissions": students_and_submissions,
-            "log_file_exists": (
-                (settings.MEDIA_ROOT / assignment.grader_log_filename).exists()
-            ),
+            "log_file_exists": ((settings.MEDIA_ROOT / assignment.grader_log_filename).exists()),
             "is_student": course.is_student_in_course(request.user),
             "is_teacher": request.user in course.teacher.all(),
             "query": query,

--- a/tin/apps/assignments/views.py
+++ b/tin/apps/assignments/views.py
@@ -392,11 +392,13 @@ def download_file_view(request, assignment_id, file_id):
         Assignment.objects.filter_editable(request.user), id=assignment_id
     )
 
-    file_name, file_path = assignment.get_file(file_id)
+    file = assignment.get_file(file_id)
 
-    with open(file_path, "rb") as f_obj:
-        response = http.HttpResponse(f_obj.read(), content_type="text/plain")
-    response["Content-Disposition"] = f'attachment; filename="{file_name}"'
+    if file is None:
+        raise http.Http404
+
+    response = http.HttpResponse(file.read_bytes(), content_type="text/plain")
+    response["Content-Disposition"] = f'attachment; filename="{file.name}"'
 
     return response
 

--- a/tin/apps/assignments/views.py
+++ b/tin/apps/assignments/views.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import csv
 import datetime
 import logging
-import os
 import subprocess
 import zipfile
 from io import BytesIO
@@ -159,7 +158,7 @@ def show_view(request, assignment_id):
             "assignment": assignment,
             "students_and_submissions": students_and_submissions,
             "log_file_exists": (
-                os.path.exists(os.path.join(settings.MEDIA_ROOT, assignment.grader_log_filename))
+                (settings.MEDIA_ROOT / assignment.grader_log_filename).exists()
             ),
             "is_student": course.is_student_in_course(request.user),
             "is_teacher": request.user in course.teacher.all(),
@@ -895,14 +894,14 @@ def download_log_view(request, assignment_id):
         Assignment.objects.filter_editable(request.user), id=assignment_id
     )
 
-    log_file_name = os.path.join(settings.MEDIA_ROOT, assignment.grader_log_filename)
+    log_file_name = settings.MEDIA_ROOT / assignment.grader_log_filename
 
     if (
         request.user not in assignment.course.teacher.all() and not request.user.is_superuser
-    ) or not os.path.exists(log_file_name):
+    ) or not log_file_name.exists():
         raise http.Http404
 
-    assigment_dir = os.path.dirname(log_file_name)
+    assigment_dir = log_file_name.parent
 
     args = sandboxing.get_assignment_sandbox_args(
         ["cat", "--", log_file_name],

--- a/tin/apps/assignments/views.py
+++ b/tin/apps/assignments/views.py
@@ -157,7 +157,7 @@ def show_view(request, assignment_id):
             "folder": assignment.folder,
             "assignment": assignment,
             "students_and_submissions": students_and_submissions,
-            "log_file_exists": ((settings.MEDIA_ROOT / assignment.grader_log_filename).exists()),
+            "log_file_exists": (settings.MEDIA_ROOT / assignment.grader_log_filename).exists(),
             "is_student": course.is_student_in_course(request.user),
             "is_teacher": request.user in course.teacher.all(),
             "query": query,

--- a/tin/apps/courses/views.py
+++ b/tin/apps/courses/views.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, timedelta
+from pathlib import Path
 
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
@@ -199,13 +200,12 @@ def import_from_selected_course(request, course_id, other_course_id):
                 old_assignment = Assignment.objects.get(id=old_id)
 
                 if form.cleaned_data["copy_graders"] and old_assignment.grader_file:
-                    with open(old_assignment.grader_file.path) as f:
-                        assignment.save_grader_file(f.read())  # Save to new directory
+                    grader_text = Path(old_assignment.grader_file.path).read_text()
+                    assignment.save_grader_file(grader_text)
 
                 if form.cleaned_data["copy_files"]:
-                    for _, filename, path, _, _ in old_assignment.list_files():
-                        with open(path) as f:
-                            assignment.save_file(f.read(), filename)
+                    for _, path, _, _ in old_assignment.list_files():
+                        assignment.save_file(path.read_text(), path.name)
 
             return redirect("courses:show", course.id)
     else:

--- a/tin/apps/submissions/models.py
+++ b/tin/apps/submissions/models.py
@@ -276,7 +276,6 @@ class Submission(models.Model):
         self.last_run = timezone.now()
         self.save()
 
-        # Is this correct?
         return run_submission.s(self.id)
 
     @property

--- a/tin/apps/venvs/models.py
+++ b/tin/apps/venvs/models.py
@@ -58,14 +58,14 @@ class Venv(models.Model):
 
     @property
     def path(self):
-        return os.path.join(settings.MEDIA_ROOT, "venvs", f"venv-{self.id}")
+        return settings.MEDIA_ROOT / "venvs" / f"venv-{self.id}"
 
     def get_activation_env(self):
         venv_path = self.path
 
         return {
             "VIRTUAL_ENV": venv_path,
-            "PATH": os.path.join(venv_path, "bin") + os.pathsep + os.environ["PATH"],
+            "PATH": str(venv_path / "bin") + os.pathsep + os.environ["PATH"],
         }
 
     def list_packages(self):

--- a/tin/apps/venvs/models.py
+++ b/tin/apps/venvs/models.py
@@ -64,7 +64,7 @@ class Venv(models.Model):
         venv_path = self.path
 
         return {
-            "VIRTUAL_ENV": venv_path,
+            "VIRTUAL_ENV": str(venv_path),
             "PATH": str(venv_path / "bin") + os.pathsep + os.environ["PATH"],
         }
 

--- a/tin/settings/__init__.py
+++ b/tin/settings/__init__.py
@@ -12,11 +12,12 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# Build paths inside the project like this: BASE_DIR / "filedir" / "file"
+BASE_DIR = Path(__file__).resolve().parent.parent
 
-MEDIA_ROOT = os.path.join(BASE_DIR, "media")
+MEDIA_ROOT = BASE_DIR / "media"
 
 
 # Quick-start development settings - unsuitable for production
@@ -84,7 +85,7 @@ ROOT_URLCONF = "tin.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [os.path.join(BASE_DIR, "templates")],
+        "DIRS": [BASE_DIR / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -122,7 +123,7 @@ TEST_RUNNER = "tin.tests.runner.PytestRunner"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
+        "NAME": BASE_DIR / "db.sqlite3",
     }
 }
 
@@ -204,8 +205,8 @@ USE_TZ = True
 
 STATIC_URL = "/static/"
 
-STATICFILES_DIRS = (os.path.join(BASE_DIR, "static"),)
-STATIC_ROOT = os.path.join(BASE_DIR, "serve")
+STATICFILES_DIRS = (BASE_DIR / "static",)
+STATIC_ROOT = BASE_DIR / "serve"
 
 
 # Logging
@@ -219,7 +220,7 @@ LOGGING = {
         "info_log": {
             "level": "INFO",
             "class": "logging.FileHandler",
-            "filename": os.path.join(BASE_DIR, "logs/info.log"),
+            "filename": BASE_DIR / "logs" / "info.log",
             "formatter": "simple",
         },
     },

--- a/tin/templates/assignments/manage_files.html
+++ b/tin/templates/assignments/manage_files.html
@@ -16,9 +16,9 @@
       <th>Last Modified</th>
     </tr>
     {% if files is not None %}
-      {% for id, filename, path, size, modified in files %}
+      {% for id, file, size, modified in files %}
         <tr>
-          <td>{{ filename }}</td>
+          <td>{{ file.name }}</td>
           <td>{{ size | filesizeformat }}</td>
           <td>{{ modified }}</td>
           <td><a href="{% url 'assignments:download_file' assignment.id id %}">Download</a></td>

--- a/tin/tests/create_users.py
+++ b/tin/tests/create_users.py
@@ -4,6 +4,8 @@ from django.contrib.auth import get_user_model
 
 __all__ = ("user_data", "add_users_to_database")
 
+# ruff: noqa: T201
+
 # fmt: off
 user_data = [
     #[username, is_teacher, is_student, is_staff, is_superuser]


### PR DESCRIPTION
See https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/

## Progress
- [X] Replace `os.path.dirname`, `os.path.join`, and `os.chmod` with `pathlib.Path` equivalents
- [X] Rewrite code to take advantage of `Path` objects