### PR TITLE
Fix incorrect docstring refs+descriptions for fixtures

### DIFF
--- a/tin/tests/assertions.py
+++ b/tin/tests/assertions.py
@@ -40,7 +40,7 @@ def is_redirect(
 
 
 def not_redirect(response: HttpResponse) -> bool:
-    """Inverse of :meth:`is_redirect`"""
+    """Inverse of :func:`is_redirect`"""
     return not is_redirect(response)
 
 
@@ -60,5 +60,5 @@ def is_login_redirect(response: HttpResponse, next: str | None = None) -> bool:
 
 
 def not_login_redirect(response: HttpResponse, **kwargs: str | None) -> bool:
-    """Inverse of :meth:`is_login_redirect`"""
+    """Inverse of :func:`is_login_redirect`"""
     return not is_login_redirect(response, **kwargs)

--- a/tin/tests/fixtures.py
+++ b/tin/tests/fixtures.py
@@ -88,11 +88,11 @@ def quiz(assignment):
 def admin_login(client):
     """Convenience fixture for logging in as admin.
 
-    Use the decorator :func:`.admin` to save writing
+    Use the decorator :func:`.login` to save writing
 
     .. code-block:: python
 
-        @pytest.mark.usefixtures("admin_login")
+        @login("admin")
         def test_redirect(client, course):
             response = client.get(reverse("assignments:edit", args=[course.id]))
             assert response.status_code != 302
@@ -104,11 +104,11 @@ def admin_login(client):
 def teacher_login(client):
     """Convenience fixture for logging in as a teacher
 
-    Use the decorator :func:`.teacher` to save writing
+    Use the decorator :func:`.login` to save writing
 
     .. code-block:: python
 
-        @pytest.mark.usefixtures("teacher_login")
+        @login("teacher")
         def test_redirect(client, course):
             response = client.get(reverse("assignments:edit", args=[course.id]))
             assert response.status_code != 302
@@ -120,11 +120,11 @@ def teacher_login(client):
 def student_login(client):
     """Convenience decorator for logging in as a teacher
 
-    Use the decorator :func:`.student` to save writing
+    Use the decorator :func:`.login` to save writing
 
     .. code-block:: python
 
-        @pytest.mark.usefixtures("student_login")
+        @login("student")
         def test_redirect(client, course):
             response = client.get(reverse("assignments:edit", args=[course.id]))
             assert response.status_code == 302


### PR DESCRIPTION
Fixes incorrect hyperlinks and outdated descriptions
See [`5c10d9d96327e468ca26358f041b3e8efa31ec10`](https://github.com/tjcsl/tin/commit/5c10d9d96327e468ca26358f041b3e8efa31ec10)