### PR TITLE
Prevent error 500 for listing files without grader

### DIFF
--- a/tin/apps/assignments/models.py
+++ b/tin/apps/assignments/models.py
@@ -289,12 +289,8 @@ class Assignment(models.Model):
         return self.venv and self.venv.fully_created
 
     @property
-    def grader_log_filename(self):
-        return (
-            upload_grader_file_path(self, "").rsplit(".", 1)[0] + ".log"
-            if self.grader_file
-            else None
-        )
+    def grader_log_filename(self) -> str:
+        return f"{upload_grader_file_path(self, '').rsplit('.', 1)[0]}.log"
 
     def quiz_open_for_student(self, student):
         is_teacher = self.course.teacher.filter(id=student.id).exists()

--- a/tin/apps/assignments/views.py
+++ b/tin/apps/assignments/views.py
@@ -159,10 +159,7 @@ def show_view(request, assignment_id):
             "assignment": assignment,
             "students_and_submissions": students_and_submissions,
             "log_file_exists": (
-                assignment.grader_log_filename is not None
-                and os.path.exists(
-                    os.path.join(settings.MEDIA_ROOT, assignment.grader_log_filename)
-                )
+                os.path.exists(os.path.join(settings.MEDIA_ROOT, assignment.grader_log_filename))
             ),
             "is_student": course.is_student_in_course(request.user),
             "is_teacher": request.user in course.teacher.all(),


### PR DESCRIPTION
For an example of the error, run `test_incorrect_files` from #40 locally