### PR TITLE
Ignore `if TYPE_CHECKING` in coverage report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ exclude_also = [
   # Don't complain about code that won't run
   "if __name__ == .__main__.:",
   # Ignore type-checking only code
-  "if (typing.)?TYPE_CHECKING:",
+  "if (typing\\.)?TYPE_CHECKING:",
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = { file = "requirements.txt" }
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "tin.settings"
-python_files = "tests.py test_*.py *_tests.py"
+python_files = "tests.py test_*.py"
 norecursedirs = ["media", "migrations", "sandboxing"]
 testpaths = "tin"
 addopts = "--doctest-modules tin --import-mode=importlib -n 8"
@@ -35,19 +35,21 @@ omit = [
     "*/apps.py",
     "*/urls.py",
     "*/wsgi.py",
+    "*/tests.py",
+    "*/test_*.py",
 ]
 relative_files = true
 
 [tool.coverage.report]
 exclude_also = [
-  # Don't complain about missing debug-only code:
-  "def __repr__",
-  # Don't complain about abstract methods, they aren't run:
-  "@(abc\\.)?abstractmethod",
-  # Don't complain about code that won't run
-  "if __name__ == .__main__.:",
-  # Ignore type-checking only code
-  "if (typing\\.)?TYPE_CHECKING:",
+    # Don't complain about missing debug-only code:
+    "def __repr__",
+    # Don't complain about abstract methods, they aren't run:
+    "@(abc\\.)?abstractmethod",
+    # Don't complain about code that won't run
+    "if __name__ == .__main__.:",
+    # Ignore type-checking only code
+    "if (typing\\.)?TYPE_CHECKING:",
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,18 @@ omit = [
 ]
 relative_files = true
 
+[tool.coverage.report]
+exclude_also = [
+  # Don't complain about missing debug-only code:
+  "def __repr__",
+  # Don't complain about abstract methods, they aren't run:
+  "@(abc\\.)?abstractmethod",
+  # Don't complain about code that won't run
+  "if __name__ == .__main__.:",
+  # Ignore type-checking only code
+  "if (typing.)?TYPE_CHECKING:",
+]
+
 [tool.black]
 line-length = 100
 exclude = '''


### PR DESCRIPTION
It was annoying me and by coincidence I found out about https://coverage.readthedocs.io/en/latest/config.html#sample-file so...
I also added test files to coverage ignore - there's no need for it to check our tests! This is probably the reason that our coverage decreased (lol), but that's probably a good thing.