### PR TITLE
Ruff python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ docs/build/
 docs/source/reference/
 
 .coverage
+
+# from prettier
+node_modules/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ show-fixes = false
 
 line-length = 100
 
-target-version = "py38"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = [

--- a/tin/apps/assignments/forms.py
+++ b/tin/apps/assignments/forms.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from logging import getLogger
-from typing import Iterable
 
 from django import forms
 from django.conf import settings

--- a/tin/apps/submissions/views.py
+++ b/tin/apps/submissions/views.py
@@ -295,7 +295,7 @@ def filter_view(request):
                     "submissions/filter.html",
                     {
                         "form": filter_form,
-                        "submissions": list(zip(queryset, submission_texts)),
+                        "submissions": list(zip(queryset, submission_texts, strict=False)),
                         "action": "show_code",
                         "nav_item": "Filter submissions",
                     },

--- a/tin/tests/utils.py
+++ b/tin/tests/utils.py
@@ -6,7 +6,8 @@ __all__ = (
     "to_html",
 )
 
-from typing import TYPE_CHECKING, Any, Callable, Literal
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Literal
 
 import pytest
 from django.template import Context, Engine


### PR DESCRIPTION
Followup to #22 - change ruff to use python 3.11 as the base version to get more up-to-date changes (from e.g. `pyupgrade`)