### PR TITLE
Explicitly order names after last name conflict

### DIFF
--- a/tin/apps/assignments/views.py
+++ b/tin/apps/assignments/views.py
@@ -88,7 +88,7 @@ def show_view(request, assignment_id):
         if query:
             active_period = "query"
             student_list = course.students.filter(full_name__icontains=query).order_by(
-                "periods", "last_name"
+                "periods", "last_name", "first_name"
             )
         elif course.period_set.exists():
             if period == "":
@@ -104,7 +104,7 @@ def show_view(request, assignment_id):
 
             if period == "all":
                 active_period = "all"
-                student_list = course.students.all().order_by("periods", "last_name")
+                student_list = course.students.all().order_by("periods", "last_name", "first_name")
             elif period == "none":
                 active_period = "none"
                 student_list = []
@@ -112,10 +112,10 @@ def show_view(request, assignment_id):
                 active_period = get_object_or_404(
                     Period.objects.filter(course=course), id=int(period)
                 )
-                student_list = active_period.students.all().order_by("last_name")
+                student_list = active_period.students.all().order_by("last_name", "first_name")
         elif period == "all":
             active_period = "all"
-            student_list = course.students.all().order_by("last_name")
+            student_list = course.students.all().order_by("last_name", "first_name")
         else:
             active_period = "none"
             student_list = []

--- a/tin/templates/assignments/show.html
+++ b/tin/templates/assignments/show.html
@@ -115,6 +115,7 @@
       {% if assignment.is_quiz %}
         <table id="submission-list" class="has-border">
           <tr>
+            <th style="min-width:20px"></th>
             <th style="min-width:125px">Student</th>
             {% if not active_period.name %}
               <th style="min-width:65px;">Period</th>
@@ -127,6 +128,7 @@
           </tr>
           {% for student, period, latest_submission, graded_submission, ended, quiz_issues in students_and_submissions %}
             <tr>
+              <td>{{ forloop.counter }}</tr>
               <td><a href="{% url 'assignments:student_submission' assignment.id student.id %}">{{ student.full_name }}
                 ({{ student.username }})</a></td>
               {% if not active_period.name %}
@@ -155,6 +157,7 @@
       {% else %}
         <table id="submission-list" class="has-border">
           <tr>
+            <th style="min-width:20px"></th>
             <th style="min-width:125px">Student</th>
             {% if not active_period.name %}
               <th style="min-width:65px;">Period</th>
@@ -168,6 +171,7 @@
           </tr>
           {% for student, period, latest_submission, graded_submission, new_login, new_24 in students_and_submissions %}
             <tr>
+              <td>{{ forloop.counter }}</td>
               <td><a href="{% url 'assignments:student_submission' assignment.id student.id %}">{{ student.full_name }}
                 ({{ student.username }})</a></td>
               {% if not active_period.name %}


### PR DESCRIPTION
- Explicitly order names by first name, in case of a last name conflict
  - The way to sort stuff in cases of identical values is not in the SQL specification, so we can't rely on that sorting a specific way.
- Adds a counter to the names (see below)

![image](https://github.com/user-attachments/assets/21c15170-d8e6-423e-a8ab-ceb430449b57)
