### PR TITLE
Add NixOS support

### DIFF
--- a/docs/source/contributing/setup.rst
+++ b/docs/source/contributing/setup.rst
@@ -42,3 +42,18 @@ Now you're all set! Try running the development server
 
 Head on over to `http://127.0.0.1:8000 <http://127.0.0.1:8000>`_, and login
 as ``admin`` and the password you just entered.
+
+
+
+NixOS Setup
+-----------
+A ``flake.nix`` file is provided for NixOS users. To use it, first enable the redis service globally.
+Place the following in your ``/etc/nixos/configuration.nix``::
+
+  services.redis.server."".enable = true
+
+After that, you can run the flake with::
+
+  nix develop
+
+You can then run the development server as stated above.

--- a/docs/source/contributing/setup.rst
+++ b/docs/source/contributing/setup.rst
@@ -57,3 +57,7 @@ After that, you can run the flake with::
   nix develop
 
 You can then run the development server as stated above.
+
+.. tip::
+
+   You may also need to set ``nix.settings.experimental-features = ["nix-command" "flakes"];`` in your ``configuration.nix``.

--- a/docs/source/contributing/setup.rst
+++ b/docs/source/contributing/setup.rst
@@ -52,11 +52,11 @@ Place the following in your ``/etc/nixos/configuration.nix``::
 
   services.redis.server."".enable = true
 
-After that, you can run the flake with::
+This will start a systemd service called ``redis``. After that, you can start the flake with::
 
   nix develop
 
-You can then run the development server as stated above.
+You can then install dependencies, setup the database, and run the development server as described above.
 
 .. tip::
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,62 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1730963269,
+        "narHash": "sha256-rz30HrFYCHiWEBCKHMffHbMdWJ35hEkcRVU0h7ms3x0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "83fb6c028368e465cd19bb127b86f971a5e41ebc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}
+

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "A flake for running Tin";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachSystem flake-utils.lib.allSystems (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.pyenv
+            pkgs.pipenv
+            pkgs.python3
+          ];
+        };
+      });
+}


### PR DESCRIPTION
## Changes
- Adds a `flake.nix` and `flake.lock`
- Updates docs on how to use them

## Testing plan
I spun up a NixOS VM, and tested it on that. The procedure for trying it out is written in the docs.