### PR TITLE
Improve development in NixOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
             pkgs.pyenv
             pkgs.pipenv
             pkgs.python3
+            pkgs.ruff
           ];
         };
       });


### PR DESCRIPTION
Improves upon #93 (but does not solve it yet).

This PR allows `ruff` to be installed and run from the Nix store (instead of as a pip package), making it work. However, `ruff` will still not work within `pre-commit`.