### PR TITLE
Set `_state.adding` when cloning models

### DIFF
--- a/tin/apps/courses/views.py
+++ b/tin/apps/courses/views.py
@@ -186,6 +186,7 @@ def import_from_selected_course(request, course_id, other_course_id):
                 for folder in form.cleaned_data["folders"]:
                     assignments = list(folder.assignments.all())
                     folder.pk = None
+                    folder._state.adding = True
                     folder.course = course
                     folder.save()
                     for assignment in assignments:
@@ -201,6 +202,7 @@ def import_from_selected_course(request, course_id, other_course_id):
 
                 # Save as new
                 assignment.pk = None
+                assignment._state.adding = True
 
                 # Update course, folder, assigned date, and grader file
                 assignment.course = course


### PR DESCRIPTION
The [docs](https://docs.djangoproject.com/en/4.2/topics/db/queries/#copying-model-instances) for cloning a model instance say to also set this attribute to `True`. This PR does just that.